### PR TITLE
Make FastAPI and uvicorn first-class dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,8 @@ A lightweight Python workflow engine. Define handlers (workflow steps) via a dec
 ### From PyPI
 
 ```bash
-# Core package (python-dotenv, httpx for Slack support)
+# Install antkeeper (includes FastAPI, uvicorn, python-dotenv, httpx)
 pip install antkeeper
-
-# With server support (adds FastAPI + uvicorn)
-pip install antkeeper[server]
-
-# All extras
-pip install antkeeper[all]
 ```
 
 ### From Source
@@ -26,8 +20,7 @@ cd antkeeper
 
 # Install with uv
 uv sync  # Development dependencies
-uv pip install .  # Core only
-uv pip install ".[all]"  # All extras
+uv pip install .  # Core package
 ```
 
 ## Requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,14 +12,10 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Framework :: FastAPI",
 ]
-dependencies = ["python-dotenv", "httpx"]
-
-[project.optional-dependencies]
-server = ["fastapi", "uvicorn[standard]"]
-all = ["antkeeper[server]"]
+dependencies = ["python-dotenv", "httpx", "fastapi", "uvicorn[standard]"]
 
 [dependency-groups]
-dev = ["pytest", "fastapi", "uvicorn[standard]", "ruff", "ty"]
+dev = ["pytest", "ruff", "ty"]
 
 [project.urls]
 Homepage = "https://github.com/mowat27/antkeeper"

--- a/uv.lock
+++ b/uv.lock
@@ -25,46 +25,32 @@ name = "antkeeper"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "fastapi" },
     { name = "httpx" },
     { name = "python-dotenv" },
-]
-
-[package.optional-dependencies]
-all = [
-    { name = "fastapi" },
-    { name = "uvicorn", extra = ["standard"] },
-]
-server = [
-    { name = "fastapi" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.dev-dependencies]
 dev = [
-    { name = "fastapi" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "ty" },
-    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "antkeeper", extras = ["server"], marker = "extra == 'all'" },
-    { name = "fastapi", marker = "extra == 'server'" },
+    { name = "fastapi" },
     { name = "httpx" },
     { name = "python-dotenv" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'" },
+    { name = "uvicorn", extras = ["standard"] },
 ]
-provides-extras = ["server", "all"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "fastapi" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "ty" },
-    { name = "uvicorn", extras = ["standard"] },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Move FastAPI and uvicorn from optional `[server]` extras to core dependencies
- Simplify installation instructions (single `pip install antkeeper` command)
- Remove `[project.optional-dependencies]` section from pyproject.toml

## Motivation
FastAPI and uvicorn should be first-class dependencies alongside CLI and Slack channels, reflecting their status as core framework components rather than optional extras.

## Changes
- **pyproject.toml**: Move `fastapi` and `uvicorn[standard]` to `dependencies`
- **README.md**: Simplify installation documentation
- **uv.lock**: Update dependency resolution

## Test plan
- [x] All 113 tests pass
- [x] Ruff linting passes
- [x] Type checking (ty) passes
- [x] Dependencies sync cleanly with `uv sync`

🤖 Generated with [Claude Code](https://claude.com/claude-code)