### PR TITLE
Fix static export for git.branch

### DIFF
--- a/src/antkeeper/git/__init__.py
+++ b/src/antkeeper/git/__init__.py
@@ -12,6 +12,7 @@ Exports:
     current: Get the name of the current git branch.
 """
 
+from antkeeper.git import branch
 from antkeeper.git.branch import current
 from antkeeper.git.core import GitCommandError, execute, latest_commit
 from antkeeper.git.worktrees import Worktree, WorktreeError, git_worktree
@@ -20,6 +21,7 @@ __all__ = [
     "GitCommandError",
     "Worktree",
     "WorktreeError",
+    "branch",
     "current",
     "execute",
     "git_worktree",


### PR DESCRIPTION
## Summary

- Add static export for `git.branch` in `src/antkeeper/git/__init__.py`

## Test plan

- [x] `from antkeeper.git import branch` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)