### PR TITLE
refactor: unify Handler protocol across core and handler packages

### DIFF
--- a/.claude/skills/design-expert/expertise.yaml
+++ b/.claude/skills/design-expert/expertise.yaml
@@ -1,6 +1,6 @@
 # Antkeeper Framework - Design Expertise
 # Mental model for the antkeeper workflow engine
-# Last validated: 2026-03-31 (branch: feature/ralph-retry-wrapper)
+# Last validated: 2026-04-10 (branch: refactor-unify-handler-protocol)
 
 overview:
   name: antkeeper
@@ -157,7 +157,7 @@ architecture:
       path: src/antkeeper/__init__.py
       responsibility: >
         Package-level re-exports. Exports all major public types via __all__:
-        App, Runner, run_workflow, State, Channel, WorkflowFailedError,
+        App, Runner, run_workflow, State, Channel, Handler, WorkflowFailedError,
         CliChannel, ApiChannel, SlackChannel, Worktree, git_worktree,
         make_log_dir, make_timestamp. Note: extract_json and json_prompt are
         NOT exported here; extract_json is imported directly from
@@ -266,6 +266,23 @@ domain_types:
       stderr; all others to stdout. This is the primary extension point for
       new I/O adapters.
 
+  Handler:
+    file: src/antkeeper/core/domain.py
+    definition: Protocol
+    attributes:
+      - "__name__: str"
+    methods:
+      - "__call__(self, runner: Runner, state: State) -> State"
+    notes: >
+      Canonical protocol for all workflow handler callables. Defined once in
+      core/domain.py and shared across the entire framework — cc_handler,
+      ralph(), App.handler decorator, and run_workflow all use this type.
+      No positional-only marker. Runner is imported under TYPE_CHECKING to
+      avoid a circular import. Exported from antkeeper.core and antkeeper
+      top-level package. Local handler protocols (_NamedHandler in ralph.py
+      and a local Handler in factories.py) were removed in favour of this
+      single definition.
+
 core_objects:
   App:
     file: src/antkeeper/core/app.py
@@ -278,12 +295,14 @@ core_objects:
       - "state_dir: str  # directory for per-run state JSON files"
       - "env: dict[str, Any | Callable[[Runner], Any]] | None  # optional env vars; values may be callables accepting (runner) returning the value"
     interface:
-      - "handler(fn) -> wrapper  # decorator that registers fn by fn.__name__"
-      - "add_handler(fn) -> None  # programmatic alternative to @app.handler decorator"
-      - "get_handler(name) -> Callable[[Runner, State], State | NoReturn]"
+      - "handler(fn: Handler) -> Handler  # decorator that wraps fn and registers the wrapper by fn.__name__"
+      - "add_handler(fn: Handler) -> None  # programmatic alternative to @app.handler decorator; stores fn directly"
+      - "get_handler(name) -> Handler"
     design_constraint: >
-      get_handler raises ValueError for unknown names. The decorator and add_handler()
-      both store the original fn in self.handlers. handlers constructor param merges
+      get_handler raises ValueError for unknown names. The decorator creates a functools.wraps
+      wrapper and stores the wrapper (not the raw fn) in self.handlers — so app.handlers[name]
+      and the decorated reference are the same callable object. add_handler() stores whatever
+      Handler is passed directly (pre-built factory outputs). handlers constructor param merges
       pre-registered handlers at construction time. log_dir can be a callable accepting
       (runner) — resolved by Runner.__init__ at construction time. env values can be
       callables accepting (runner) — resolved by Runner.run() before passing to _app_env.
@@ -334,10 +353,11 @@ core_objects:
 
   run_workflow:
     file: src/antkeeper/core/app.py
-    signature: "run_workflow(runner: Runner, state: State, steps: list[Callable], skip: int = 0) -> State"
+    signature: "run_workflow(runner: Runner, state: State, steps: list[Handler], skip: int = 0) -> State"
     responsibility: >
-      Sequential composition helper. Folds state through a list of handler
-      callables. Logs step names and completion via runner.logger.
+      Sequential composition helper. Folds state through a list of Handler callables.
+      Logs step names and completion via runner.logger. Uses step.__name__ directly
+      (no getattr fallback) — Handler protocol guarantees __name__ is always present.
     progress_tracking: >
       Before the first step, inserts _progress: {"total": len(steps), "completed": skip}
       into state and immediately calls runner._persist_state(). External observers can
@@ -581,13 +601,13 @@ handler_factories:
     file: src/antkeeper/handlers/ralph.py
     signature: |
       ralph(
-          handler: _NamedHandler,
+          handler: Handler,
           *,
           validator: _Validator | str,
           max_retries: int = 3,
           prompt_key: str = "prompt",
           label: str | None = None,
-      ) -> _NamedHandler
+      ) -> Handler
     returns: Handler callable with __name__ set to resolved label
     responsibility: >
       Factory that wraps any handler with a retry-validation loop. On each attempt the
@@ -595,15 +615,14 @@ handler_factories:
       feedback is appended to a progress log and the prompt is augmented with prior-attempts
       context before the next attempt. On exhaustion, runner.fail() raises WorkflowFailedError.
       Has zero LLM dependencies — wraps any callable matching (Runner, State) -> State with __name__.
+      Uses antkeeper.core.domain.Handler for parameter and return type (the local _NamedHandler
+      protocol has been removed).
     types:
       ValidationResult:
         kind: frozen dataclass
         fields:
           - "success: bool"
           - "feedback: str"
-      _NamedHandler:
-        kind: Protocol
-        description: "A handler callable with __name__: str attribute"
       _Validator:
         kind: type alias
         definition: "Callable[[State], ValidationResult]"
@@ -890,12 +909,12 @@ testing_design:
 
 key_design_decisions:
   - "Reducer pattern: handlers receive (runner, state) -> State. State is always a new dict (spread), never mutated, never shared between runs."
-  - "Channel and Agent are Protocols (structural subtyping, not ABCs). Channel.report(run_id, StreamEvent) is the single I/O method."
+  - "Channel, Handler, and Agent are Protocols (structural subtyping, not ABCs). Channel.report(run_id, StreamEvent) is the single I/O method. Handler is the single canonical type for all workflow callables — defined once in core/domain.py and shared by App, run_workflow, cc_handler, and ralph. No local handler protocols exist in handlers/."
   - "runner.fail() raises WorkflowFailedError (not exit). CLI catches and exits 1; API background task catches and continues serving."
   - "run_workflow enables composition without DAG: handlers call run_workflow with a step list."
   - "CLI loads user code dynamically via importlib (load_app); agents file must export `app`. Prompt from files or piped stdin into state['prompt']."
   - "cc_handler: verbosity filtering is the channel's concern, not the factory. All events forwarded unconditionally to runner.channel.report()."
-  - "ralph() wraps any (Runner,State)->State handler with __name__. Zero LLM dependencies. Exceptions propagate immediately (no retry)."
+  - "ralph() wraps any Handler (core protocol). Zero LLM dependencies. Exceptions propagate immediately (no retry). cc_handler(), @app.handler, and ralph() all produce and consume the same Handler type — full composition without casts."
   - "Git worktree isolation: one worktree per run on feature/slug branch. App.worktree_dir = 'trees/' default."
   - "Server factory: create_app() loads agents file, returns FastAPI. Routes defined inline in server.py; logic delegated to http/ package."
   - "Slack: debounce via SlackEventProcessor (instance-scoped pending store). SlackChannel uses sync httpx; server endpoint uses async httpx."

--- a/app_docs/README.md
+++ b/app_docs/README.md
@@ -6,7 +6,7 @@ This directory contains policy and pattern documentation for the Antkeeper workf
 
 - **reference.md** - Comprehensive reference guide covering project structure, core concepts in detail, writing handlers (decorator pattern, cc_handler factory, and the ralph retry-with-validation wrapper), LLM integration, git utilities, data flow for all channels (CLI, API, Slack, Programmatic), logging and state persistence, CLI commands, and codebase navigation. This is where readers go after the main README for detailed technical reference.
 
-- **releasing.md** - Packaging, dependency management, and PyPI release process. Covers core dependencies (all runtime deps including OTel packages), public API exports (including `ProgrammaticChannel`), entry points (CLI script and Python module), environment variables (`ANTKEEPER_HANDLERS_FILE`), package metadata, build system (uv_build), release checklist, publishing to PyPI, post-release verification, and version numbering strategy.
+- **releasing.md** - Packaging, dependency management, and PyPI release process. Covers core dependencies (all runtime deps including OTel packages), public API exports (including `Handler` and `ProgrammaticChannel`), entry points (CLI script and Python module), environment variables (`ANTKEEPER_HANDLERS_FILE`), package metadata, build system (uv_build), release checklist, publishing to PyPI, post-release verification, and version numbering strategy.
 
 - **standards.md** - Engineering standards that guide framework decisions. Covers dependency philosophy (not a micro-library — add core deps without hesitation) and performance philosophy (LLM calls dominate; never optimise framework internals for speed).
 

--- a/app_docs/reference.md
+++ b/app_docs/reference.md
@@ -7,7 +7,7 @@ Detailed reference for the Antkeeper workflow framework. For an introduction to 
 ```
 src/antkeeper/
 ├── core/               # Framework kernel
-│   ├── domain.py       # State type alias, Channel protocol, WorkflowFailedError
+│   ├── domain.py       # State type alias, Channel protocol, Handler protocol, WorkflowFailedError
 │   ├── app.py          # App handler registry, run_workflow helper
 │   └── runner.py       # Runner execution engine
 ├── channels/
@@ -164,7 +164,7 @@ def sdlc(runner, state):
 
 ### Retry-with-Validation Wrapper (ralph)
 
-The `ralph()` factory wraps any handler with a retry-validation loop. It works with `@app.handler`-decorated handlers, `cc_handler`-built handlers, or any plain callable matching `(Runner, State) -> State`.
+The `ralph()` factory wraps any handler with a retry-validation loop. It works with `@app.handler`-decorated handlers, `cc_handler`-built handlers, or any plain callable satisfying the `Handler` protocol (`(Runner, State) -> State` with a `__name__` attribute).
 
 ```python
 from antkeeper.handlers.ralph import ralph, ValidationResult
@@ -181,13 +181,13 @@ wrapped = ralph(my_handler, validator=my_validator, max_retries=3)
 
 ```python
 ralph(
-    handler: Callable[[Runner, State], State],
+    handler: Handler,
     *,
     validator: Callable[[State], ValidationResult] | str,
     max_retries: int = 3,
     prompt_key: str = "prompt",
     label: str | None = None,
-) -> Callable[[Runner, State], State]
+) -> Handler
 ```
 
 **Parameters:**

--- a/app_docs/releasing.md
+++ b/app_docs/releasing.md
@@ -44,6 +44,7 @@ from antkeeper import (
     run_workflow,
     State,
     Channel,
+    Handler,
     WorkflowFailedError,
     CliChannel,
     ApiChannel,
@@ -71,7 +72,7 @@ from antkeeper.channels.programmatic import ProgrammaticChannel
 
 and include it in `__all__`.
 
-**Namespace policy**: The top-level `antkeeper` namespace is reserved for high-level workflow constructs (App, Runner, Channel implementations, State). Lower-level utilities are accessed via submodules:
+**Namespace policy**: The top-level `antkeeper` namespace is reserved for high-level workflow constructs (App, Runner, Channel implementations, State, Channel, Handler). Lower-level utilities are accessed via submodules:
 - Git utilities: `from antkeeper.git import execute, current, GitCommandError`
 - LLM agents: `from antkeeper.llm.claude_code import ClaudeCodeAgent, run_prompt`
 - Domain types: `from antkeeper.core.domain import StreamEvent`
@@ -190,7 +191,7 @@ Before publishing to PyPI:
 
 1. **Update version** in `pyproject.toml`
 2. **Run quality checks**: `just` (lint + typecheck + test)
-3. **Verify imports**: `python -c "from antkeeper import App, Runner, run_workflow, CliChannel, State, Channel, WorkflowFailedError, ApiChannel, SlackChannel, ProgrammaticChannel, Worktree, git_worktree, make_log_dir, make_timestamp; print('All imports OK')"` (ensure `ProgrammaticChannel` has been added to `__init__.py` first)
+3. **Verify imports**: `python -c "from antkeeper import App, Runner, run_workflow, CliChannel, State, Channel, Handler, WorkflowFailedError, ApiChannel, SlackChannel, ProgrammaticChannel, Worktree, git_worktree, make_log_dir, make_timestamp; print('All imports OK')"` (ensure `ProgrammaticChannel` has been added to `__init__.py` first)
 4. **Test CLI invocation**: `python -m antkeeper` (should print help), `antkeeper init` (should scaffold handlers.py)
 5. **Build package**: `uv build`
 6. **Test installation**: `uv pip install dist/antkeeper-*.whl` in a fresh venv

--- a/app_docs/testing_policy.md
+++ b/app_docs/testing_policy.md
@@ -275,6 +275,26 @@ def test_something(app, runner_factory):
     # State files go to app.state_dir (temp directory)
 ```
 
+### App Decorator Registry Testing Patterns
+
+Tests for the `@app.handler` decorator's registry behaviour live in `tests/core/test_app.py`:
+
+- `test_handler_decorator_stores_wrapper_in_registry` — After `@app.handler`, `app.handlers[name]` is the wrapper, not the raw function (`app.handlers[name] is not raw_fn`).
+- `test_handler_decorator_registry_and_return_are_same_object` — The object returned by `app.handler(fn)` and the object stored in `app.handlers[fn.__name__]` are the same (`is` check). This means the decorated name and the registry lookup always refer to the same callable.
+
+These tests verify the identity invariant introduced by the refactor that unified the `Handler` protocol: storing the wrapper (not the raw function) in the registry ensures `get_handler()` returns the same object as the decorated name.
+
+### Handler Composability Testing Patterns
+
+Tests for composing handlers across `@app.handler`, `cc_handler`, `ralph`, and `run_workflow` live in `tests/core/test_workflows.py` in the `TestHandlerComposability` class:
+
+- `test_decorated_handler_usable_in_run_workflow` — a `@app.handler` decorated function passed as a step to `run_workflow` executes correctly.
+- `test_mixed_handler_sources_in_run_workflow` — a `steps` list containing a plain function (no decorator) and a decorated handler both execute in sequence.
+- `test_decorated_handler_composable_with_ralph` — `ralph(decorated_fn, validator=v)` produces a handler that runs correctly in `run_workflow`.
+- `test_ralph_wrapping_cc_handler_pattern` — a handler mimicking `cc_handler` output (plain function with `__name__` set), wrapped with `ralph`, runs in `run_workflow`. Verifies the full composition chain without requiring the Claude Code CLI.
+
+These tests assert that handlers from all three sources (`@app.handler`, `cc_handler`, and plain callables satisfying the `Handler` protocol) are interchangeable in `run_workflow` and `ralph`.
+
 ### App Environment Variable Testing Patterns
 
 Tests for the `App(env=...)` feature live in `tests/core/test_workflows.py` in the `TestAppEnvironment` class, alongside the workflow execution tests. Constructor-level tests (`test_app_constructor_stores_env`, `test_app_constructor_default_env_is_none`) live in `tests/core/test_app.py`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "antkeeper"
-version = "0.1.5"
+version = "v0.1.6"
 description = "Workflow engine with handler registration, channel-based I/O, and remote execution"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/specs/refactor-unify-handler-protocol.md
+++ b/specs/refactor-unify-handler-protocol.md
@@ -1,0 +1,173 @@
+# refactor: Unify handler type into single core Protocol
+
+- Promote a canonical `Handler` protocol into `antkeeper.core.domain` so every handler source shares one type.
+- Delete duplicate local protocols in `factories.py` and `ralph.py`; all handler-accepting APIs use the core type.
+- Fix `App.handler` decorator to store the wrapper (not raw fn) in the registry for identity consistency.
+
+## Solution Design
+
+### Architectural Schema Changes
+
+```yaml
+types:
+  Handler:
+    kind: protocol
+    module: antkeeper.core.domain
+    attributes:
+      - __name__: str
+    methods:
+      - __call__(self, runner: Runner, state: State) -> State  # positional-or-keyword, NO /
+
+  # Changed signatures in App
+  App.handler:
+    was: "Callable[..., Any] -> Callable[..., Any]"
+    now: "Handler -> Handler"
+
+  App.add_handler:
+    was: "fn: Callable"
+    now: "fn: Handler"
+
+  App.get_handler:
+    was: "-> Callable[[Runner, State], State | NoReturn]"
+    now: "-> Handler"
+
+  run_workflow:
+    steps:
+      was: "list[Callable[[Runner, State], State]]"
+      now: "list[Handler]"
+```
+
+## Relevant Files
+
+- `src/antkeeper/core/domain.py` — Add the `Handler` protocol here alongside `State`, `Channel`, `StreamEvent`, `WorkflowFailedError`. Needs `Runner` import under `TYPE_CHECKING`.
+- `src/antkeeper/core/app.py` — Tighten all handler type annotations to `Handler`. Change decorator to store wrapper in registry. Collapse `State | NoReturn` to `State`. Simplify `getattr(__name__)` fallbacks to `step.__name__`.
+- `src/antkeeper/core/__init__.py` — Export `Handler` from the core package.
+- `src/antkeeper/handlers/claude_code/factories.py` — Delete local `Handler` protocol (lines 134–147). Import `Handler` from `antkeeper.core.domain`.
+- `src/antkeeper/handlers/ralph.py` — Delete `_NamedHandler` protocol (lines 21–26). Import `Handler` from `antkeeper.core.domain`. Update type annotations on `ralph()`.
+- `src/antkeeper/__init__.py` — Add `Handler` to top-level re-exports if other core types are exported there.
+- `tests/core/test_app.py` — Add tests for decorator registry identity.
+- `tests/core/test_workflows.py` — Add handler composability tests.
+
+## Workflow
+
+### Step 1: Add `Handler` protocol to `core/domain.py`
+
+- Add `from __future__ import annotations` at the top of `domain.py` (needed for forward-referencing `Runner`).
+- Add `TYPE_CHECKING` import guard for `Runner` (same pattern used in `app.py` and `ralph.py`).
+- Add `Protocol` to the existing `typing` import.
+- Define the `Handler` protocol after the `Channel` protocol:
+  ```python
+  class Handler(Protocol):
+      """A workflow handler callable with a __name__ attribute."""
+      __name__: str
+      def __call__(self, runner: Runner, state: State) -> State: ...
+  ```
+- No positional-only marker (`/`).
+
+### Step 2: Export `Handler` from `core/__init__.py`
+
+- Add `Handler` to the imports from `antkeeper.core.domain` in `core/__init__.py`.
+- Check `src/antkeeper/__init__.py` and add `Handler` to top-level exports if other core types are re-exported there.
+
+### Step 3: Tighten `core/app.py` type annotations
+
+- Import `Handler` from `antkeeper.core.domain`.
+- `App.handler` method:
+  - Parameter annotation: `fn: Handler`.
+  - Return annotation: `Handler`.
+  - `wrapper` return annotation: `State` (remove `| NoReturn`).
+  - Change `self.handlers[name] = fn` to `self.handlers[name] = wrapper`.
+- `App.add_handler`: parameter type `fn: Handler`.
+- `App.get_handler`: return type `Handler`.
+- `run_workflow`: `steps` parameter type `list[Handler]`.
+- Replace `getattr(step, '__name__', repr(step))` with `step.__name__` on lines 214 and 223 (and the span attributes on line 230).
+- Remove `NoReturn` from the `typing` import if no longer used elsewhere in the file.
+
+### Step 4: Delete local protocol in `factories.py`
+
+- Delete the `Handler` class (lines 134–147) from `handlers/claude_code/factories.py`.
+- Add `from antkeeper.core.domain import Handler` (or adjust the existing `domain` import line).
+- Verify `cc_handler` return type annotation still references `Handler` — it should, now pointing at the core type.
+
+### Step 5: Delete local protocol in `ralph.py`
+
+- Delete the `_NamedHandler` class (lines 21–26) from `handlers/ralph.py`.
+- Add `Handler` to the existing `from antkeeper.core.domain import State` import.
+- Change `ralph()` signature: `handler: Handler` parameter, `-> Handler` return type (lines 111, 117).
+- Remove `Protocol` from the `typing` import if no longer used.
+
+### Step 6: Add tests
+
+- See Testing Strategy below.
+
+### Step 7: Validate
+
+- Run all validation commands.
+
+## Testing Strategy
+
+### Unit Tests
+
+**`tests/core/test_app.py`** — add:
+
+- `test_handler_decorator_stores_wrapper_in_registry` — After `@app.handler`, `app.handlers[name]` is the wrapper, not the raw function. Verify `app.handlers[name] is not raw_fn`.
+- `test_handler_decorator_registry_and_return_are_same_object` — `decorated = app.handler(fn)` and `app.handlers[fn.__name__]` are the same object (`is` check).
+
+**`tests/core/test_workflows.py`** — add:
+
+- `test_decorated_handler_usable_in_run_workflow` — `@app.handler` decorated function passed as a step to `run_workflow` executes correctly.
+- `test_mixed_handler_sources_in_run_workflow` — A `steps` list containing a plain function and a decorated handler all execute in sequence.
+- `test_decorated_handler_composable_with_ralph` — `ralph(decorated_fn, validator=v)` works and the resulting handler runs in `run_workflow`.
+- `test_ralph_wrapping_cc_handler_pattern` — Define a handler mimicking `cc_handler` output (function with `__name__` set), wrap with `ralph`, pass to `run_workflow`. Verifies the full composition chain without requiring Claude Code CLI.
+
+### Edge Cases
+
+- A lambda assigned to a variable still has `__name__ == "<lambda>"` — verify `run_workflow` handles this without crashing.
+- A handler defined with `**kwargs` in its signature still satisfies the protocol and works in `run_workflow`.
+- Existing tests in `test_app.py` and `test_workflows.py` must continue to pass unchanged — the registry storage change should not break `test_app_constructor_with_handlers_dict` (constructor path is unaffected) or `test_multi_step_workflow` (uses `@app.handler` decorated functions as steps).
+
+## Acceptance Criteria
+
+- `just` (ruff + ty + tests) passes cleanly with no handler-related type errors.
+- `cc_handler(...)` output can be passed directly to `ralph(...)` with no casts or type-checker complaints.
+- `@app.handler`-decorated functions can be passed to `ralph(...)` and included in `run_workflow(...)` step lists without casts.
+- A handler produced by `ralph(cc_handler(...))` can itself be included in a `run_workflow` step list and re-wrapped.
+- `app.handlers[name]` (registry lookup) and the bound decorated name refer to the same callable object.
+- No changes to the public call sites of `run_workflow`, `cc_handler`, or `ralph`. Downstream projects importing these symbols continue to work unmodified.
+- All existing tests pass without modification.
+
+### Validation Commands
+
+```bash
+# Full standard checks (ruff + ty + tests)
+just
+
+# Verify no remaining local Handler/NamedHandler protocols
+rg "class Handler\(Protocol\)" src/antkeeper/handlers/
+rg "class _NamedHandler" src/antkeeper/
+
+# Verify Handler is exported from core
+python -c "from antkeeper.core import Handler; print(Handler)"
+
+# Verify no getattr __name__ fallbacks remain in app.py
+rg "getattr.*__name__" src/antkeeper/core/app.py
+```
+
+IMPORTANT: If any of the checks above fail you must investigate and fix the error. It is not acceptable to simply explain away the problem. You must reach zero errors, zero warnings before you move on. This includes pre-existing issues and other issues that you don't think are related to this bugfix.
+
+## Notes
+
+- `Runner.fail` is already annotated `-> NoReturn` (runner.py line 217). No change needed there.
+- The `App.handler` wrapper is a plain forwarder via `functools.wraps`. Storing it in the registry instead of the raw fn means `get_handler` returns the wrapper. Since the wrapper just calls `fn(runner, state)`, runtime behavior is identical — but now `app.handlers[name]` and the decorated reference are the same object.
+- The `add_handler` path stores whatever `Handler` is passed directly. This is intentional — `add_handler` is for pre-built handlers (factory outputs etc), while the decorator creates its own wrapper. Both paths store a `Handler`.
+- The `test_app_constructor_with_handlers_dict` test uses the constructor `handlers={}` kwarg which bypasses the decorator entirely and is unaffected by the registry storage change.
+
+## Report
+
+Report the following on completion:
+
+- Files changed (with line-count delta)
+- Tests added (names and what they verify)
+- Validation command results (pass/fail for each)
+- Confirmation that `Handler` is importable from `antkeeper.core`
+- Confirmation that no local handler protocols remain in `src/antkeeper/handlers/`

--- a/src/antkeeper/__init__.py
+++ b/src/antkeeper/__init__.py
@@ -1,10 +1,44 @@
 """Antkeeper: A lightweight workflow framework for building agentic systems.
 
 Antkeeper provides a simple, composable architecture for defining workflows
-with handlers, state management, and multiple execution channels.
+with handlers, state management, and multiple execution channels (CLI, API,
+Slack).  All public symbols are re-exported from this top-level package so
+that application code only needs a single import site::
+
+    from antkeeper import App, Runner, CliChannel, State
+
+Public API
+----------
+App
+    Central handler registry; use the ``@app.handler`` decorator to register
+    workflow functions.
+Runner
+    Executes a registered workflow for a given channel, wiring together
+    logging, state persistence, and progress reporting.
+run_workflow
+    Helper for running an ordered sequence of handler steps with automatic
+    progress tracking and resume support.
+State
+    Type alias for workflow data (``dict[str, Any]``).
+Channel
+    Protocol that all channel implementations must satisfy.
+Handler
+    Protocol for workflow handler callables.
+WorkflowFailedError
+    Exception raised (via ``Runner.fail()``) to signal a fatal workflow error.
+CliChannel
+    Channel implementation for command-line execution.
+ApiChannel
+    Channel implementation for HTTP/API execution.
+SlackChannel
+    Channel implementation for Slack-driven execution.
+Worktree, git_worktree
+    Utilities for managing git worktrees inside workflow handlers.
+make_log_dir, make_timestamp
+    Timestamp helpers used when constructing log-file paths.
 """
 
-from antkeeper.core.domain import State, Channel, WorkflowFailedError
+from antkeeper.core.domain import State, Channel, Handler, WorkflowFailedError
 from antkeeper.core.app import App, run_workflow
 from antkeeper.core.runner import Runner
 from antkeeper.channels.cli import CliChannel
@@ -19,6 +53,7 @@ __all__ = [
     "run_workflow",
     "State",
     "Channel",
+    "Handler",
     "WorkflowFailedError",
     "CliChannel",
     "ApiChannel",

--- a/src/antkeeper/core/__init__.py
+++ b/src/antkeeper/core/__init__.py
@@ -8,6 +8,7 @@ The core framework consists of:
 - Runner: Workflow execution engine with logging and state persistence
 - State: Type alias for workflow data (dict[str, Any])
 - Channel: Protocol for I/O boundaries and workflow configuration
+- Handler: Protocol for workflow handler callables
 - WorkflowFailedError: Exception for signaling workflow failures
 
 State conventions
@@ -47,3 +48,9 @@ Typical usage::
     runner = Runner(app, channel)
     final_state = runner.run()
 """
+
+from antkeeper.core.domain import Handler
+
+__all__ = ["Handler"]
+# Handler is re-exported here so that ``from antkeeper.core import Handler``
+# works alongside the fuller import path ``antkeeper.core.domain.Handler``.

--- a/src/antkeeper/core/app.py
+++ b/src/antkeeper/core/app.py
@@ -1,23 +1,32 @@
 """Application framework for registering and managing workflow handlers.
 
-This module provides:
-- _app_env: Context manager that temporarily sets os.environ variables for a block
-- App: Central registry for workflow handlers with decorator-based registration
-- run_workflow: Helper function for executing sequential handler chains
+Public API
+----------
+App
+    Central registry for workflow handlers with decorator-based registration.
+    Create one ``App`` instance per application, register handlers with
+    ``@app.handler``, then pass the instance to a ``Runner`` for execution.
+run_workflow
+    Helper function for executing an ordered chain of handler steps with
+    automatic progress tracking and resume support.
 
-The App class is the main entry point for defining workflows. Use the @app.handler
-decorator to register workflow functions, then pass the app to a Runner for execution.
+Internal helpers
+----------------
+_app_env
+    Context manager that temporarily sets ``os.environ`` variables for the
+    duration of a handler invocation and restores originals on exit.  Used
+    internally by ``Runner``; not part of the public API.
 """
 from __future__ import annotations
 
 import functools
 import os
 from contextlib import contextmanager
-from typing import Any, Callable, Generator, NoReturn, TYPE_CHECKING
+from typing import Any, Callable, Generator, TYPE_CHECKING
 
 from opentelemetry import trace
 
-from antkeeper.core.domain import State
+from antkeeper.core.domain import Handler, State
 
 if TYPE_CHECKING:
     from antkeeper.core.runner import Runner
@@ -114,7 +123,7 @@ class App:
         if handlers:
             self.handlers.update(handlers)
 
-    def add_handler(self, fn: Callable) -> None:
+    def add_handler(self, fn: Handler) -> None:
         """Register a function as a handler using its __name__ as the key.
 
         Programmatic equivalent of @app.handler. If a handler with the same
@@ -123,31 +132,31 @@ class App:
         Args:
             fn: The handler function to register.
         """
-        self.handlers[fn.__name__] = fn  # type: ignore[attr-defined]
+        self.handlers[fn.__name__] = fn
 
-    def handler(self, fn: Callable[..., Any]) -> Callable[..., Any]:
+    def handler(self, fn: Handler) -> Handler:
         """Register a function as a workflow handler.
 
         This decorator registers a workflow handler function and wraps it for execution.
         The handler's name becomes its registry key for lookup by runners.
 
         Args:
-            fn: A callable that accepts a Runner and State and returns a State
-                or NoReturn (exits). The function's name is used as the handler key.
+            fn: A callable that accepts a Runner and State and returns a State.
+                The function's name is used as the handler key.
 
         Returns:
             The wrapped handler function that can be invoked by runners.
         """
         @functools.wraps(fn)
-        def wrapper(runner: Runner, state: State) -> State | NoReturn:
+        def wrapper(runner: Runner, state: State) -> State:
             """Invoke the wrapped handler, forwarding runner and state."""
             return fn(runner, state)
 
-        name: str = fn.__name__  # type: ignore[attr-defined]
-        self.handlers[name] = fn
+        name: str = fn.__name__
+        self.handlers[name] = wrapper
         return wrapper
 
-    def get_handler(self, name: str) -> Callable[[Runner, State], State | NoReturn]:
+    def get_handler(self, name: str) -> Handler:
         """Retrieve a registered handler by name.
 
         Args:
@@ -165,7 +174,7 @@ class App:
             raise ValueError(f"Unknown handler: {name}")
 
 
-def run_workflow(runner: Runner, state: State, steps: list[Callable[[Runner, State], State]], skip: int = 0) -> State:
+def run_workflow(runner: Runner, state: State, steps: list[Handler], skip: int = 0) -> State:
     """Execute a sequence of workflow steps with state threading.
 
     Each step receives the runner and the current state, processes it, and
@@ -211,7 +220,7 @@ def run_workflow(runner: Runner, state: State, steps: list[Callable[[Runner, Sta
     if skip == 0 and resume_skip > 0:
         skip = resume_skip
 
-    runner.logger.info(f"run_workflow started with {len(steps)} steps: {[getattr(s, '__name__', repr(s)) for s in steps]}")
+    runner.logger.info(f"run_workflow started with {len(steps)} steps: {[s.__name__ for s in steps]}")
     if skip > 0:
         runner.logger.info(f"Resuming: skipping {skip} completed steps")
     # Initialise progress and persist immediately so the state file reflects
@@ -220,7 +229,7 @@ def run_workflow(runner: Runner, state: State, steps: list[Callable[[Runner, Sta
     runner._persist_state(state)
     tracer = trace.get_tracer("antkeeper")
     for i, step in enumerate(steps[skip:], start=skip):
-        step_name = getattr(step, "__name__", repr(step))
+        step_name = step.__name__
         runner.logger.info(f"Executing step: {step_name}")
         with tracer.start_as_current_span(
             "antkeeper.workflow.step",

--- a/src/antkeeper/core/domain.py
+++ b/src/antkeeper/core/domain.py
@@ -4,13 +4,19 @@ This module defines the fundamental types used throughout the framework:
 - State: Type alias for workflow data (dict[str, Any])
 - StreamEvent: Dataclass for streaming LLM events
 - Channel: Protocol for I/O boundaries and workflow configuration
+- Handler: Protocol for workflow handler callables
 
 These types form the foundation for handler signatures and runner operations.
 """
+from __future__ import annotations
+
 import dataclasses
 import json
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import Any, Protocol, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from antkeeper.core.runner import Runner
 
 
 class WorkflowFailedError(Exception):
@@ -68,25 +74,71 @@ class StreamEvent:
 class Channel(Protocol):
     """Protocol for communication channels that drive workflow execution.
 
-    Channels serve as I/O boundaries for workflows, defining what workflow to
-    run (workflow_name), what data to start with (initial_state), and how to
-    report events. Implementations adapt workflows to different environments
-    like CLI, web servers, or message queues.
+    Channels serve as the I/O boundary for a workflow.  They declare which
+    workflow to run, the initial state to seed it with, and how to surface
+    progress events to the outside world (stdout, HTTP response, Slack
+    message, etc.).
+
+    Implementations adapt the framework to different runtime environments —
+    ``CliChannel`` for the command line, ``ApiChannel`` for HTTP endpoints,
+    and ``SlackChannel`` for Slack-triggered workflows.
 
     Attributes:
-        type: The channel type identifier (e.g., "cli", "api", "web").
-        workflow_name: The name of the workflow to execute.
-        initial_state: The initial state dictionary for the workflow.
+        type: Short identifier for the channel kind (e.g. ``"cli"``,
+            ``"api"``, ``"slack"``).  Used in log messages and metadata.
+        workflow_name: Name of the workflow handler to execute.  Must match
+            a key registered in the ``App`` handler registry.
+        initial_state: Seed state dictionary passed to the workflow before
+            the first handler runs.
     """
+
     type: str
     workflow_name: str
     initial_state: State
 
     def report(self, run_id: str, event: StreamEvent) -> None:
-        """Report a workflow event.
+        """Surface a workflow event to the channel's audience.
+
+        Called by the ``Runner`` whenever a handler emits a ``StreamEvent``
+        (progress update, assistant message, tool call, result, or error).
 
         Args:
-            run_id: Unique identifier for the workflow run.
-            event: The stream event to report.
+            run_id: Unique identifier for the current workflow execution.
+            event: The stream event to surface.
+        """
+        ...
+
+
+class Handler(Protocol):
+    """A workflow handler callable.
+
+    Any function (or callable object) that accepts a ``Runner`` and a ``State``
+    and returns an updated ``State`` satisfies this protocol.  The ``__name__``
+    attribute is required so that handlers can be looked up by name in the
+    ``App`` registry and referenced in log messages.
+
+    Example::
+
+        def my_handler(runner: Runner, state: State) -> State:
+            runner.report_progress("Processing…")
+            return {**state, "processed": True}
+
+    Attributes:
+        __name__: Unique name used as the handler's registry key.
+    """
+
+    __name__: str
+
+    def __call__(self, runner: Runner, state: State) -> State:
+        """Execute the handler.
+
+        Args:
+            runner: The active ``Runner`` instance, providing logging,
+                progress reporting, and state persistence helpers.
+            state: The current workflow state dictionary.  Treat as
+                immutable — return a new dict with any updates.
+
+        Returns:
+            The updated workflow state.
         """
         ...

--- a/src/antkeeper/handlers/claude_code/factories.py
+++ b/src/antkeeper/handlers/claude_code/factories.py
@@ -26,11 +26,10 @@ skipping (defaults to ``True`` for backward compatibility).
 import logging
 import re
 from collections.abc import Callable, Iterator
-from typing import Protocol
 
 from antkeeper.core.app import _app_env
 from antkeeper.core.runner import Runner
-from antkeeper.core.domain import State, StreamEvent
+from antkeeper.core.domain import Handler, State, StreamEvent
 from antkeeper.helpers.json import extract_json
 from antkeeper.llm.claude_code import ClaudeCodeAgent, run_prompt
 from antkeeper.llm.errors import AgentExecutionError
@@ -129,22 +128,6 @@ def _extraction_middleware(
                         internal=True,
                     )
     return middleware
-
-
-class Handler(Protocol):
-    """A handler callable with a ``__name__`` attribute.
-
-    Attributes:
-        __name__: Human-readable label used in progress messages and logging.
-
-    Methods:
-        __call__: Run the handler against the given runner and state, returning
-            updated state.
-    """
-
-    __name__: str
-
-    def __call__(self, runner: Runner, state: State, /) -> State: ...
 
 
 def cc_handler(

--- a/src/antkeeper/handlers/ralph.py
+++ b/src/antkeeper/handlers/ralph.py
@@ -10,20 +10,12 @@ import json
 import os
 import subprocess
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable, Protocol
+from typing import TYPE_CHECKING, Callable
 
-from antkeeper.core.domain import State
+from antkeeper.core.domain import Handler, State
 
 if TYPE_CHECKING:
     from antkeeper.core.runner import Runner
-
-
-class _NamedHandler(Protocol):
-    """A handler callable that exposes a ``__name__`` attribute."""
-    __name__: str
-
-    def __call__(self, runner: Runner, state: State) -> State:
-        ...
 
 
 _Validator = Callable[["State"], "ValidationResult"]
@@ -108,13 +100,13 @@ def _state_diff(before: State, after: State) -> str:
 
 
 def ralph(
-    handler: _NamedHandler,
+    handler: Handler,
     *,
     validator: _Validator | str,
     max_retries: int = 3,
     prompt_key: str = "prompt",
     label: str | None = None,
-) -> _NamedHandler:
+) -> Handler:
     """Wrap a handler with a retry-validation loop.
 
     On each attempt the inner handler is called, then the validator is invoked.

--- a/tests/core/test_app.py
+++ b/tests/core/test_app.py
@@ -1,8 +1,12 @@
-"""Tests for App constructor handlers param and add_handler method.
+"""Tests for the App class public API.
 
-Verifies that App correctly stores handlers supplied at construction time,
-supports dynamic handler registration via add_handler, and manages the
-optional env parameter.
+Covers:
+
+* ``handlers`` constructor parameter — handlers dict supplied at build time.
+* ``add_handler`` — dynamic handler registration keyed by ``__name__``.
+* ``env`` constructor parameter — storage and default (``None``) behaviour.
+* ``@app.handler`` decorator — wrapping, registry storage, and identity of
+  the returned callable.
 """
 
 from antkeeper.core.app import App
@@ -57,3 +61,25 @@ def test_app_constructor_default_env_is_none():
     """Test that App defaults env to None when not provided."""
     app = App()
     assert app.env is None
+
+
+def test_handler_decorator_stores_wrapper_in_registry():
+    """After @app.handler, app.handlers[name] is the wrapper, not the raw function."""
+    app = App()
+
+    def raw_fn(runner, state):
+        return state
+
+    app.handler(raw_fn)
+    assert app.handlers["raw_fn"] is not raw_fn
+
+
+def test_handler_decorator_registry_and_return_are_same_object():
+    """decorated = app.handler(fn) and app.handlers[fn.__name__] are the same object."""
+    app = App()
+
+    def my_handler(runner, state):
+        return state
+
+    decorated = app.handler(my_handler)
+    assert app.handlers["my_handler"] is decorated

--- a/tests/core/test_workflows.py
+++ b/tests/core/test_workflows.py
@@ -1,7 +1,18 @@
 """Core workflow execution tests.
 
-Tests the framework's ability to execute single handlers, multi-step workflows,
-error handling, and handler resolution.
+Covers the full surface area of workflow execution in the Antkeeper framework:
+
+* Basic execution — single-handler and multi-step sequential workflows.
+* Error handling — ``WorkflowFailedError`` propagation and unknown handler lookup.
+* App environment — ``env`` lifecycle (set before handler, restored after success
+  and failure, callable env values, mixed static/callable maps).
+* Progress tracking — ``_progress`` injection, per-step increment, and initial
+  persistence to disk via ``run_workflow``.
+* Callable ``log_dir`` — resolver receives the Runner, resulting dir is created.
+* Skip / resume — ``skip`` parameter, ``_resume_skip`` state key, precedence rules.
+* Handler composability — plain functions, ``@app.handler`` decorated handlers,
+  ``ralph``-wrapped handlers, and handlers with ``**kwargs``, all usable as
+  ``run_workflow`` steps.
 """
 
 import json
@@ -633,3 +644,113 @@ class TestWorkflowSkip:
         result = runner.run()
         assert result["steps"] == ["c"]
         assert "_resume_skip" not in result
+
+
+class TestHandlerComposability:
+    """Tests for handler protocol composability across decorators, ralph, and run_workflow."""
+
+    def test_decorated_handler_usable_in_run_workflow(self, app, runner_factory):
+        """@app.handler decorated function passed as a step to run_workflow executes correctly."""
+
+        @app.handler
+        def increment(runner, state: State) -> State:
+            return {**state, "n": state["n"] + 1}
+
+        @app.handler
+        def use_increment(runner, state: State) -> State:
+            return run_workflow(runner, state, [increment])
+
+        runner, _ = runner_factory(app, "use_increment", {"n": 0})
+        result = runner.run()
+        assert result["n"] == 1
+
+    def test_mixed_handler_sources_in_run_workflow(self, app, runner_factory):
+        """A steps list containing a plain function and a decorated handler all execute in sequence."""
+
+        def plain_step(runner, state: State) -> State:
+            return {**state, "steps": state.get("steps", []) + ["plain"]}
+
+        @app.handler
+        def decorated_step(runner, state: State) -> State:
+            return {**state, "steps": state.get("steps", []) + ["decorated"]}
+
+        @app.handler
+        def orchestrator(runner, state: State) -> State:
+            return run_workflow(runner, state, [plain_step, decorated_step])
+
+        runner, _ = runner_factory(app, "orchestrator", {})
+        result = runner.run()
+        assert result["steps"] == ["plain", "decorated"]
+
+    def test_decorated_handler_composable_with_ralph(self, app, runner_factory):
+        """ralph(decorated_fn, validator=v) works and the resulting handler runs in run_workflow."""
+        from antkeeper.handlers.ralph import ralph, ValidationResult
+
+        @app.handler
+        def do_work(runner, state: State) -> State:
+            return {**state, "done": True}
+
+        def always_pass(state: State) -> ValidationResult:
+            return ValidationResult(success=True, feedback="")
+
+        wrapped = ralph(do_work, validator=always_pass)
+
+        @app.handler
+        def orchestrator(runner, state: State) -> State:
+            return run_workflow(runner, state, [wrapped])
+
+        runner, _ = runner_factory(app, "orchestrator", {})
+        result = runner.run()
+        assert result["done"] is True
+
+    def test_ralph_wrapping_cc_handler_pattern(self, app, runner_factory):
+        """A handler mimicking cc_handler output, wrapped with ralph, runs in run_workflow."""
+        from antkeeper.handlers.ralph import ralph, ValidationResult
+
+        def fake_cc_handler(runner, state: State) -> State:
+            return {**state, "cc_ran": True}
+
+        fake_cc_handler.__name__ = "fake_cc"
+
+        def always_pass(state: State) -> ValidationResult:
+            return ValidationResult(success=True, feedback="")
+
+        wrapped = ralph(fake_cc_handler, validator=always_pass)
+
+        @app.handler
+        def orchestrator(runner, state: State) -> State:
+            return run_workflow(runner, state, [wrapped])
+
+        runner, _ = runner_factory(app, "orchestrator", {})
+        result = runner.run()
+        assert result["cc_ran"] is True
+
+    def test_lambda_handler_in_run_workflow(self, app, runner_factory):
+        """A lambda assigned to a variable still works in run_workflow (has __name__ == '<lambda>')."""
+        def step(runner, state):
+            return {**state, "lambda_ran": True}
+        step.__name__ = "<lambda>"
+
+        @app.handler
+        def orchestrator(runner, state: State) -> State:
+            return run_workflow(runner, state, [step])
+
+        runner, _ = runner_factory(app, "orchestrator", {})
+        result = runner.run()
+        assert result["lambda_ran"] is True
+
+    def test_handler_with_kwargs_in_run_workflow(self, app, runner_factory):
+        """A handler defined with **kwargs satisfies the protocol and works in run_workflow."""
+
+        def flexible_handler(runner, state, **kwargs):
+            return {**state, "flex": True}
+
+        flexible_handler.__name__ = "flexible"
+
+        @app.handler
+        def orchestrator(runner, state: State) -> State:
+            return run_workflow(runner, state, [flexible_handler])
+
+        runner, _ = runner_factory(app, "orchestrator", {})
+        result = runner.run()
+        assert result["flex"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "antkeeper"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Promote a canonical `Handler` protocol into `antkeeper.core.domain`; delete the duplicate local protocols in `handlers/claude_code/factories.py` and `handlers/ralph.py`.
- Tighten `App.handler`, `App.add_handler`, `App.get_handler`, and `run_workflow` to use the core `Handler` type so decorated functions, `cc_handler` outputs, and `ralph` wrappers compose freely without type-checker friction.
- Fix a latent divergence in `App.handler`: the decorator now stores the `wrapper` (not the raw `fn`) in the registry, so direct-name calls and `get_handler` lookups reference the same callable.

## Why

Three overlapping notions of "what a handler is" (raw `Callable` in core, local `Handler` with positional-only `__call__` in `cc_handler`, local `_NamedHandler` with positional-or-keyword `__call__` in `ralph`) caused strict type checkers to reject passing `cc_handler` output directly to `ralph()` — even though runtime behaviour was fine. This friction blocks the "infinitely composable" property that should be the core structural guarantee of the framework. The refactor collapses the three into one and lets the type system enforce that closure.

## Test plan

- [x] `tests/core/test_app.py` — new assertions that `app.handler` decorator stores the wrapper in the registry and that the returned callable is identity-equal to the registered one.
- [x] `tests/core/test_workflows.py` — new `TestHandlerComposability` class covers decorated handlers in `run_workflow`, mixed plain + decorated steps, `ralph`-wrapped decorated handlers, `ralph`-wrapped `cc_handler`-shaped functions, lambda-style handlers, and handlers taking `**kwargs`.
- [x] `just` (ruff + ty + tests) passes cleanly in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)